### PR TITLE
fix: replace missing variable with valid one

### DIFF
--- a/lessons/ajax.md
+++ b/lessons/ajax.md
@@ -42,7 +42,7 @@ promise
     return processingPromise;
   })
   .then(function(processedResponse) {
-    console.log(breeds);
+    console.log(processedResponse);
   });
 
 console.log("this will log first");


### PR DESCRIPTION
'breeds' is never defined