### PR TITLE
Typo fix (complement > compliment)

### DIFF
--- a/lessons/node.md
+++ b/lessons/node.md
@@ -58,7 +58,7 @@ app.get("/", function(req, res) {
   res.end("Welcome to my site!");
 });
 
-app.get("/complement", function(req, res) {
+app.get("/compliment", function(req, res) {
   res.end("You look nice today");
 });
 
@@ -69,20 +69,20 @@ console.log("listening on http://localhost:3000");
 Looks pretty similar, right? Express is pretty thin (doesn't do _too_ much) which is great. Let's break it down.
 
 * `const app = express();` is how you create a new server.
-* `app.get(url, callback);` is how you handle a new route. A route is how you handle the request when a user hits a particular URL. In this case we set up two, the default home page, `/`, and `/complement`. Try visiting both `http://localhost:3000` and `http://localhost:3000/complement`. If you try a different URL from those, it'll give a 404 not found error.
+* `app.get(url, callback);` is how you handle a new route. A route is how you handle the request when a user hits a particular URL. In this case we set up two, the default home page, `/`, and `/compliment`. Try visiting both `http://localhost:3000` and `http://localhost:3000/compliment`. If you try a different URL from those, it'll give a 404 not found error.
 
-Otherwise it's pretty similar, right? Let's go one step further and make it serve a front end. Make a new folder in your project called `public`. Every file we put in here we're going to serve publically so don't put anything sensitive in here (like passwords or access keys.) Make a file called `complements.js` in this public folder.
+Otherwise it's pretty similar, right? Let's go one step further and make it serve a front end. Make a new folder in your project called `public`. Every file we put in here we're going to serve publically so don't put anything sensitive in here (like passwords or access keys.) Make a file called `compliments.js` in this public folder.
 
 ```js
 document
-  .querySelector(".request-complement")
+  .querySelector(".request-compliment")
   .addEventListener("click", function() {
-    fetch("/complement")
+    fetch("/compliment")
       .then(function(res) {
         return res.json();
       })
       .then(function(data) {
-        document.querySelector(".complement").innerText = data.complement;
+        document.querySelector(".compliment").innerText = data.compliment;
       })
       .catch(function(err) {
         console.error(err);
@@ -90,7 +90,7 @@ document
   });
 ```
 
-Mostly nothing new here. The `/complement` path means it's going to request it from the same server that this was served from. In this case it'd be http://localhost:3000/complement
+Mostly nothing new here. The `/compliment` path means it's going to request it from the same server that this was served from. In this case it'd be http://localhost:3000/compliment
 
 Make new index.html in the root directory of this project (where server.js and package.json are.) Put in it:
 
@@ -99,20 +99,20 @@ Make new index.html in the root directory of this project (where server.js and p
 <html lang="en">
 
 <head>
-  <title>Complements</title>
+  <title>Compliments</title>
 </head>
 
 <body>
-  <h1>Complements!</h1>
-  <p class="complement">none loaded yet</p>
-  <button class="request-complement">Request New Complement</button>
-  <script src="./public/complements.js"></script>
+  <h1>Compliments!</h1>
+  <p class="compliment">none loaded yet</p>
+  <button class="request-compliment">Request New Compliment</button>
+  <script src="./public/compliments.js"></script>
 </body>
 
 </html>
 ```
 
-Nothing new here either. Notice we are requesting the complements.js file from the public directory.
+Nothing new here either. Notice we are requesting the compliments.js file from the public directory.
 
 Refactor (a word which means rework your code) your server.js file to look like:
 
@@ -120,7 +120,7 @@ Refactor (a word which means rework your code) your server.js file to look like:
 const express = require("express");
 const path = require("path");
 
-const complements = [
+const compliments = [
   "You like nice today",
   "That dress looks nice on you",
   "Have you been working out?",
@@ -132,9 +132,9 @@ const complements = [
   "You've learned a lot of things, and that's pretty hard to do"
 ];
 
-function getRandomComplement() {
-  const randomIndex = Math.floor(Math.random() * complements.length);
-  return complements[randomIndex];
+function getRandomCompliment() {
+  const randomIndex = Math.floor(Math.random() * compliments.length);
+  return compliments[randomIndex];
 }
 
 const app = express();
@@ -143,10 +143,10 @@ app.get("/", function(req, res) {
   res.sendFile(path.join(__dirname, "index.html"));
 });
 
-app.get("/complement", function(req, res) {
+app.get("/compliment", function(req, res) {
   res
     .json({
-      complement: getRandomComplement()
+      compliment: getRandomCompliment()
     })
     .end();
 });
@@ -159,9 +159,9 @@ console.log("listening on http://localhost:3000");
 
 Alright! A bit here but let's work it out!
 
-* The `getRandomComplement` function returns a random item from the `complements` array. `Math.random()` gives you a random number between 0 and 1. We take that and multiply that by how long the `complements` array is (which is cool because we can add and subtract items from the `complements` array and not change this function). This is basically the same as saying we're going take a 0%-100% randomly of the array length. We'll end up with a number like `2.16231583252359`. We need that to be a whole number so it's a useful index, so we say `Math.floor()` which gives us that number rounding down, so `Math.floor(3.9)` is 3 (there's also `Math.ceil` to round up and `Math.round` to round how we normally do.) The result is we get a random number between 0 (the first element of an element array) and `complements.length - 1` (the last element of the array). We then use that to return a random element from `complements`!
+* The `getRandomCompliment` function returns a random item from the `compliments` array. `Math.random()` gives you a random number between 0 and 1. We take that and multiply that by how long the `compliments` array is (which is cool because we can add and subtract items from the `compliments` array and not change this function). This is basically the same as saying we're going take a 0%-100% randomly of the array length. We'll end up with a number like `2.16231583252359`. We need that to be a whole number so it's a useful index, so we say `Math.floor()` which gives us that number rounding down, so `Math.floor(3.9)` is 3 (there's also `Math.ceil` to round up and `Math.round` to round how we normally do.) The result is we get a random number between 0 (the first element of an element array) and `compliments.length - 1` (the last element of the array). We then use that to return a random element from `compliments`!
 * `res.sendFile(path.join(__dirname, "index.html"));` sends the user the `index.html` we just created. `path` is a libray for getting correct file locations. In this case, we're getting the whole path to it so Express can find it. `__dirname` is a special Node variable that's the folder of where the server.js file is. We know that index.html is in the same folder, so we're saying serve the index.html file found in the same directory as server.js.
-* `res.json({ complement: getRandomComplement() }).end();` - This is going to respond to the request with a `JSON` object, just like dog.ceo was doing. It's going to be a small object with just one key: `complement`. The value to that key is going to be one of the random complements generated by that function.
+* `res.json({ compliment: getRandomCompliment() }).end();` - This is going to respond to the request with a `JSON` object, just like dog.ceo was doing. It's going to be a small object with just one key: `compliment`. The value to that key is going to be one of the random compliments generated by that function.
 * `app.use("/public", express.static("./public"));` serves everything in the public directory publicly. We'll put stuff in here like images, client JS files, CSS files, and anything else we need users to be able to download from our server. Part of what this does is set all the correct headers which you need to do. The browser will request a resource like `my-styles.css` but the browser needs to know how to read that file: is it an image or is it a CSS file? (it doesn't look at the file extension). It then serves everything inside it from the path on the server `/public`. We happened to call the folder and the path from the server the same thing but you don't have to (though it's smart to.)
 
 That's it! You made your own full web app!


### PR DESCRIPTION
Changed all occurrences of [C/c]omplement to [C/c]ompliment in node.md, as the latter spelling is the correct word for saying nice things about someone.

Sources:
https://www.grammarly.com/blog/complement-compliment/
https://www.dictionary.com/e/compliment-vs-complement/